### PR TITLE
Updated deps, fixes type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ and this project tries to adhere to
 
 ### Fixed
 
-- Argument of type '(site: Site) => void' is not assignable to parameter of type
-  'Plugin'.
+- Fixed type-error by updating Lume
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and this project tries to adhere to
 	**Security** in case of vulnerabilities.
 -->
 
+## 0.2.1 - 2022-10-11
+
+### Fixed
+
+- Argument of type '(site: Site) => void' is not assignable to parameter of type
+  'Plugin'.
+
+### Changed
+
+- Update deps
+  - lume@1.12.0
+  - std@0.159.0
+
 ## 0.2.0 - 2022-07-13
 
 ### Added

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export * as path from 'https://deno.land/std@0.148.0/path/mod.ts';
-export type { Site } from 'https://deno.land/x/lume@v1.10.0/core.ts';
-export { Page } from 'https://deno.land/x/lume@v1.10.0/core/filesystem.ts';
+export * as path from 'https://deno.land/std@0.159.0/path/mod.ts';
+export type { Site } from 'https://deno.land/x/lume@v1.12.0/core.ts';
+export { Page } from 'https://deno.land/x/lume@v1.12.0/core/filesystem.ts';
 export { default as CleanCSS } from 'https://esm.sh/clean-css@5.3.1';


### PR DESCRIPTION
Hi,
I wanted to use the plugin on the lume.land site and it was throwing a type error.
I updated the deps to fix the error. Can you please release the new version?